### PR TITLE
correctly apply custom face setting

### DIFF
--- a/column-enforce-mode.el
+++ b/column-enforce-mode.el
@@ -233,7 +233,7 @@ mark text that extends beyond `column-enforce-column' with the \
             (let ((new-ov (make-overlay (point)
                                         (point-at-eol)
                                         nil t t)))
-              (overlay-put new-ov 'face 'column-enforce-face)
+              (overlay-put new-ov 'face column-enforce-face)
               (overlay-put new-ov 'is-cem-ov t)))
         (forward-line 1)))))
 


### PR DESCRIPTION
This fixes an issue: the face named `column-enforce-face` was being used directly, ignoring any custom setting in the variable named `column-enforce-face`.

I have tested the fix by redefining `column-enforce-warn-on-region` in my init file and checking that the default face is still applied; then by customizing the variable `column-enforce-face` and checking that the custom face is applied.